### PR TITLE
feat: allow all TabBar props to be overridden

### DIFF
--- a/src/views/MaterialTopTabBar.js
+++ b/src/views/MaterialTopTabBar.js
@@ -148,12 +148,12 @@ export default class TabBarTop extends React.PureComponent<Props> {
 
     return (
       <TabBar
-        {...rest}
         activeColor={activeTintColor}
         inactiveColor={inactiveTintColor}
         navigationState={navigation.state}
         renderIcon={this._renderIcon}
         renderLabel={this._renderLabel}
+        {...rest}
       />
     );
   }


### PR DESCRIPTION
This will allow the `renderIcon` and `renderLabel` props to be overridden so that tabs can be styled.